### PR TITLE
Rtl 48 be 서브 타임라인 공개여부 설정

### DIFF
--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
@@ -82,8 +82,8 @@ public class SubTimelineController {
 
     // 사용자 본인의 서브타임라인 조회 API
     @GetMapping("/my")
-    public ResponseEntity<List<SubTimeline>> getMySubTimelines() {
-        List<SubTimeline> mySubTimelines = subTimelineService.getMySubTimelines();
+    public ResponseEntity<List<SubMyTimelineResponseDTO>> getMySubTimelines() {
+        List<SubMyTimelineResponseDTO> mySubTimelines = subTimelineService.getMySubTimelines();
         return ResponseEntity.ok(mySubTimelines);
     }
 

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
@@ -72,5 +72,26 @@ public class SubTimelineController {
         SubTimelineWithLikeBookmarkDTO dto = subTimelineService.getSubTimelineWithLikeAndBookmark(subTimelineId);
         return ResponseEntity.ok(dto);
     }
+
+    // 서브타임라인 공개/비공개 설정 API
+    @PutMapping("/{subTimelineId}/privacy")
+    public ResponseEntity<Void> setSubTimelinePrivacy(@PathVariable Long subTimelineId, @RequestParam boolean isPrivate) {
+        subTimelineService.setSubTimelinePrivacy(subTimelineId, isPrivate);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 사용자 본인의 서브타임라인 조회 API
+    @GetMapping("/my")
+    public ResponseEntity<List<SubTimeline>> getMySubTimelines() {
+        List<SubTimeline> mySubTimelines = subTimelineService.getMySubTimelines();
+        return ResponseEntity.ok(mySubTimelines);
+    }
+
+    // 전체 서브타임라인 조회 (비공개 제외, 시작 날짜 순서대로 정렬)
+    @GetMapping("/main/{mainTimelineId}")
+    public ResponseEntity<List<SubReadResponseDTO>> getAllSubTimelinesByMainTimelineId(@PathVariable Long mainTimelineId) {
+        List<SubTimeline> subTimelines = subTimelineService.getAllSubTimelinesByMainTimelineId(mainTimelineId);
+        return ResponseEntity.ok(SubReadResponseDTO.from(subTimelines));
+    }
 }
 

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
@@ -75,9 +75,9 @@ public class SubTimelineController {
 
     // 서브타임라인 공개/비공개 설정 API
     @PutMapping("/{subTimelineId}/privacy")
-    public ResponseEntity<Void> setSubTimelinePrivacy(@PathVariable Long subTimelineId, @RequestParam boolean isPrivate) {
-        subTimelineService.setSubTimelinePrivacy(subTimelineId, isPrivate);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<SubPrivacyUpdateResponseDTO> setSubTimelinePrivacy(@PathVariable Long subTimelineId, @RequestParam boolean isPrivate) {
+        SubPrivacyUpdateResponseDTO response = subTimelineService.setSubTimelinePrivacy(subTimelineId, isPrivate);
+        return ResponseEntity.ok(response);
     }
 
     // 사용자 본인의 서브타임라인 조회 API

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
@@ -89,9 +89,10 @@ public class SubTimelineController {
 
     // 전체 서브타임라인 조회 (비공개 제외, 시작 날짜 순서대로 정렬)
     @GetMapping("/main/{mainTimelineId}")
-    public ResponseEntity<List<SubReadResponseDTO>> getAllSubTimelinesByMainTimelineId(@PathVariable Long mainTimelineId) {
+    public ResponseEntity<SubReadResponseDTO> getAllSubTimelinesByMainTimelineId(@PathVariable Long mainTimelineId) {
         List<SubTimeline> subTimelines = subTimelineService.getAllSubTimelinesByMainTimelineId(mainTimelineId);
-        return ResponseEntity.ok(SubReadResponseDTO.from(subTimelines));
+        String mainTimelineTitle = subTimelineService.getMainTimelineTitle(mainTimelineId);
+        return ResponseEntity.ok(SubReadResponseDTO.from(subTimelines, mainTimelineTitle));
     }
 }
 

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/domain/SubTimeline.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/domain/SubTimeline.java
@@ -42,6 +42,9 @@ public class SubTimeline extends BaseEntity {
     @Column(nullable = false)
     private int likeCount = 0; // 좋아요 수 필드 추가 및 초기값 설정
 
+    @Column(name = "is_private", nullable = false)
+    private boolean isPrivate; // 공개/비공개 여부
+
     // 북마크 수가 음수가 되지 않도록 검증 메서드 추가
     public void adjustBookmarkCount(int adjustment) {
         this.bookmarkCount += adjustment;

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubMyTimelineResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubMyTimelineResponseDTO.java
@@ -1,0 +1,35 @@
+package com.api.RecordTimeline.domain.subTimeline.dto.response;
+
+import com.api.RecordTimeline.domain.subTimeline.domain.SubTimeline;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class SubMyTimelineResponseDTO {
+
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private int likeCount;
+    private int bookmarkCount;
+    private boolean isPrivate;
+
+    // 서브타임라인에서 DTO 생성하는 메서드
+    public static SubMyTimelineResponseDTO from(SubTimeline subTimeline) {
+        return new SubMyTimelineResponseDTO(
+                subTimeline.getId(),
+                subTimeline.getTitle(),
+                subTimeline.getContent(),
+                subTimeline.getStartDate(),
+                subTimeline.getEndDate(),
+                subTimeline.getLikeCount(),
+                subTimeline.getBookmarkCount(),
+                subTimeline.isPrivate()
+        );
+    }
+}

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubPrivacyUpdateResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubPrivacyUpdateResponseDTO.java
@@ -1,0 +1,19 @@
+package com.api.RecordTimeline.domain.subTimeline.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubPrivacyUpdateResponseDTO {
+    private String code;
+    private String message;
+
+    public static SubPrivacyUpdateResponseDTO success(String message) {
+        return new SubPrivacyUpdateResponseDTO("SU", message);
+    }
+
+    public static SubPrivacyUpdateResponseDTO failure(String message) {
+        return new SubPrivacyUpdateResponseDTO("UF", message);
+    }
+}

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubReadResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubReadResponseDTO.java
@@ -42,21 +42,26 @@ public class SubReadResponseDTO {
         return new SubReadResponseDTO(details, mainTimelineTitle);
     }
 
-    public static List<SubReadResponseDTO> from(List<SubTimeline> subTimelines) {
-        return subTimelines.stream()
-                .map(subTimeline -> new SubReadResponseDTO(
-                        List.of(new SubTimelineDetails(
-                                subTimeline.getId(),
-                                subTimeline.getTitle(),
-                                subTimeline.getContent(),
-                                subTimeline.getStartDate(),
-                                subTimeline.getEndDate(),
-                                subTimeline.getLikeCount(),
-                                subTimeline.getBookmarkCount(),
-                                subTimeline.isPrivate()
-                        )),
-                        null  // 메인 타임라인 제목이 없는 경우 null로 설정
-                ))
-                .collect(Collectors.toList());
+    // 모든 서브타임라인을 가져오는 경우 호출 (비공개 제외)
+    public static SubReadResponseDTO from(List<SubTimeline> subTimelines) {
+        if (subTimelines.isEmpty()) {
+            return new SubReadResponseDTO(List.of(), null);
+        }
+
+        // 모든 서브타임라인은 같은 메인 타임라인에 속해 있으므로 첫 번째 타임라인의 메인 타임라인 제목을 가져옴
+        String mainTimelineTitle = subTimelines.get(0).getMainTimeline().getTitle();
+
+        List<SubTimelineDetails> details = subTimelines.stream()
+                .map(subTimeline -> new SubTimelineDetails(
+                        subTimeline.getId(),
+                        subTimeline.getTitle(),
+                        subTimeline.getContent(),
+                        subTimeline.getStartDate(),
+                        subTimeline.getEndDate(),
+                        subTimeline.getLikeCount(),
+                        subTimeline.getBookmarkCount(),
+                        subTimeline.isPrivate()
+                )).collect(Collectors.toList());
+        return new SubReadResponseDTO(details, mainTimelineTitle);
     }
 }

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubReadResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubReadResponseDTO.java
@@ -24,6 +24,7 @@ public class SubReadResponseDTO {
         private LocalDate endDate;
         private int likeCount;
         private int bookmarkCount;
+        private boolean isPrivate;
     }
 
     public static SubReadResponseDTO from(List<SubTimeline> subTimelines, String mainTimelineTitle) {
@@ -35,8 +36,27 @@ public class SubReadResponseDTO {
                         subTimeline.getStartDate(),
                         subTimeline.getEndDate(),
                         subTimeline.getLikeCount(),
-                        subTimeline.getBookmarkCount()
+                        subTimeline.getBookmarkCount(),
+                        subTimeline.isPrivate()
                 )).collect(Collectors.toList());
         return new SubReadResponseDTO(details, mainTimelineTitle);
+    }
+
+    public static List<SubReadResponseDTO> from(List<SubTimeline> subTimelines) {
+        return subTimelines.stream()
+                .map(subTimeline -> new SubReadResponseDTO(
+                        List.of(new SubTimelineDetails(
+                                subTimeline.getId(),
+                                subTimeline.getTitle(),
+                                subTimeline.getContent(),
+                                subTimeline.getStartDate(),
+                                subTimeline.getEndDate(),
+                                subTimeline.getLikeCount(),
+                                subTimeline.getBookmarkCount(),
+                                subTimeline.isPrivate()
+                        )),
+                        null  // 메인 타임라인 제목이 없는 경우 null로 설정
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/repository/SubTimelineRepository.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/repository/SubTimelineRepository.java
@@ -45,6 +45,9 @@ public interface SubTimelineRepository extends JpaRepository<SubTimeline, Long> 
             """, nativeQuery = true)
     List<SubTimeline> findSubTimelinesByInterest(String interest);
 
+    List<SubTimeline> findByMainTimeline_Member_IdOrderByStartDateAsc(Long memberId);
+
+    List<SubTimeline> findByMainTimelineIdOrderByStartDateAsc(Long mainTimelineId);
 }
 
 

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
@@ -9,6 +9,7 @@ import com.api.RecordTimeline.domain.member.repository.MemberRepository;
 import com.api.RecordTimeline.domain.subTimeline.domain.SubTimeline;
 import com.api.RecordTimeline.domain.subTimeline.dto.request.SubTimelineCreateRequest;
 //import com.api.RecordTimeline.domain.subTimeline.dto.response.AccessDeniedResponseDTO;
+import com.api.RecordTimeline.domain.subTimeline.dto.response.SubMyTimelineResponseDTO;
 import com.api.RecordTimeline.domain.subTimeline.dto.response.SubPrivacyUpdateResponseDTO;
 import com.api.RecordTimeline.domain.subTimeline.dto.response.SubTimelineWithLikeBookmarkDTO;
 import com.api.RecordTimeline.domain.subTimeline.repository.SubTimelineRepository;
@@ -234,9 +235,14 @@ public class SubTimelineService {
     }
 
     // 사용자 본인의 서브타임라인 조회 (토큰 필요)
-    public List<SubTimeline> getMySubTimelines() {
+    public List<SubMyTimelineResponseDTO> getMySubTimelines() {
         Member member = getCurrentAuthenticatedMember();
-        return subTimelineRepository.findByMainTimeline_Member_IdOrderByStartDateAsc(member.getId());
+        List<SubTimeline> subTimelines = subTimelineRepository.findByMainTimeline_Member_IdOrderByStartDateAsc(member.getId());
+
+        // 서브타임라인 엔티티를 SubMyTimelineResponseDTO로 변환하여 리스트로 반환
+        return subTimelines.stream()
+                .map(SubMyTimelineResponseDTO::from)
+                .collect(Collectors.toList());
     }
 
     // 모든 서브타임라인 조회 (비공개 제외, 시작 날짜 순서대로 정렬)

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -206,7 +207,8 @@ public class SubTimelineService {
             throw new ApiException(ErrorType._ACCESS_DENIED);
         }
 
-        return subTimelineRepository.findByMainTimelineIdOrderByStartDate(mainTimelineId);
+        //return subTimelineRepository.findByMainTimelineIdOrderByStartDate(mainTimelineId);
+        return subTimelineRepository.findByMainTimelineIdOrderByStartDateAsc(mainTimelineId);
     }
 
     // 메인타임라인 제목을 가져오는 메서드 추가
@@ -214,6 +216,31 @@ public class SubTimelineService {
         return mainTimelineRepository.findById(mainTimelineId)
                 .map(MainTimeline::getTitle)
                 .orElseThrow(() -> new IllegalArgumentException("해당 메인타임라인을 찾을 수 없습니다. : " + mainTimelineId));
+    }
+
+    // 서브타임라인 공개/비공개 설정
+    public void setSubTimelinePrivacy(Long subTimelineId, boolean isPrivate) {
+        SubTimeline subTimeline = subTimelineRepository.findById(subTimelineId)
+                .orElseThrow(() -> new ApiException(ErrorType._SUBTIMELINE_NOT_FOUND));
+
+        checkOwnership(subTimeline.getMainTimeline().getMember().getEmail());
+
+        subTimeline.setPrivate(isPrivate);
+        subTimelineRepository.save(subTimeline);
+    }
+
+    // 사용자 본인의 서브타임라인 조회 (토큰 필요)
+    public List<SubTimeline> getMySubTimelines() {
+        Member member = getCurrentAuthenticatedMember();
+        return subTimelineRepository.findByMainTimeline_Member_IdOrderByStartDateAsc(member.getId());
+    }
+
+    // 모든 서브타임라인 조회 (비공개 제외, 시작 날짜 순서대로 정렬)
+    public List<SubTimeline> getAllSubTimelinesByMainTimelineId(Long mainTimelineId) {
+        return subTimelineRepository.findByMainTimelineId(mainTimelineId).stream()
+                .filter(subTimeline -> !subTimeline.isPrivate())
+                .sorted(Comparator.comparing(SubTimeline::getStartDate))  // 시작 날짜 순서대로 정렬
+                .collect(Collectors.toList());
     }
 
     private void checkOwnership(String ownerEmail) {

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
@@ -9,6 +9,7 @@ import com.api.RecordTimeline.domain.member.repository.MemberRepository;
 import com.api.RecordTimeline.domain.subTimeline.domain.SubTimeline;
 import com.api.RecordTimeline.domain.subTimeline.dto.request.SubTimelineCreateRequest;
 //import com.api.RecordTimeline.domain.subTimeline.dto.response.AccessDeniedResponseDTO;
+import com.api.RecordTimeline.domain.subTimeline.dto.response.SubPrivacyUpdateResponseDTO;
 import com.api.RecordTimeline.domain.subTimeline.dto.response.SubTimelineWithLikeBookmarkDTO;
 import com.api.RecordTimeline.domain.subTimeline.repository.SubTimelineRepository;
 import com.api.RecordTimeline.global.exception.ApiException;
@@ -219,7 +220,7 @@ public class SubTimelineService {
     }
 
     // 서브타임라인 공개/비공개 설정
-    public void setSubTimelinePrivacy(Long subTimelineId, boolean isPrivate) {
+    public SubPrivacyUpdateResponseDTO setSubTimelinePrivacy(Long subTimelineId, boolean isPrivate) {
         SubTimeline subTimeline = subTimelineRepository.findById(subTimelineId)
                 .orElseThrow(() -> new ApiException(ErrorType._SUBTIMELINE_NOT_FOUND));
 
@@ -227,6 +228,9 @@ public class SubTimelineService {
 
         subTimeline.setPrivate(isPrivate);
         subTimelineRepository.save(subTimeline);
+
+        String message = isPrivate ? "서브타임라인이 비공개 처리 되었습니다." : "서브타임라인이 공개 처리 되었습니다.";
+        return SubPrivacyUpdateResponseDTO.success(message);
     }
 
     // 사용자 본인의 서브타임라인 조회 (토큰 필요)


### PR DESCRIPTION
# 📝 서브타임라인 공개/비공개 설정 및 사용자 본인 서브타임라인 조회 기능 추가


<br>


- [x] 서브타임라인 공개/비공개 설정 기능 추가
- [x] 사용자 본인 서브타임라인 조회 기능: 자신이 비공개한 서브타임라인도 포함하여 조회 가능
- [x] 전체 서브타임라인 조회 기능 수정 및 추가: 비공개 서브타임라인을 제외하고 시작 날짜 순으로 조회 가능 / 메인타임라인 제목과 함께 서브타임라인 목록 반환함.
- [x] 추가 기능이나 변경할 기능 있는지 검토 요청