### PR TITLE
feat: 진행중/완료 isDone 필드 추가 및 API 생성

### DIFF
--- a/src/main/java/com/api/RecordTimeline/domain/mainTimeline/controller/MainTimelineController.java
+++ b/src/main/java/com/api/RecordTimeline/domain/mainTimeline/controller/MainTimelineController.java
@@ -46,7 +46,7 @@ public class MainTimelineController {
             return ResponseEntity.noContent().build();
         }
         List<ReadResponseDTO.TimelineDetails> details = timelines.stream()
-                .map(timeline -> new ReadResponseDTO.TimelineDetails(timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate()))
+                .map(timeline -> new ReadResponseDTO.TimelineDetails(timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate(), timeline.isDone()))
                 .collect(Collectors.toList());
         return ResponseEntity.ok(details);
     }
@@ -59,7 +59,7 @@ public class MainTimelineController {
             return ResponseEntity.noContent().build();  // 내용이 없을 경우 No Content 상태 반환
         }
         List<ReadResponseDTO.TimelineDetails> details = timelines.stream()
-                .map(timeline -> new ReadResponseDTO.TimelineDetails(timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate()))
+                .map(timeline -> new ReadResponseDTO.TimelineDetails(timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate(), timeline.isDone()))
                 .collect(Collectors.toList());
         return ResponseEntity.ok(details);
     }
@@ -70,7 +70,7 @@ public class MainTimelineController {
         try {
             MainTimeline timeline = mainTimelineService.getMainTimelineById(id);
             ReadResponseDTO response = new ReadResponseDTO(List.of(new ReadResponseDTO.TimelineDetails(
-                    timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate()
+                    timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate(), timeline.isDone()
             )));
             return ResponseEntity.ok(response);
         } catch (NoSuchElementException e) {
@@ -114,4 +114,18 @@ public class MainTimelineController {
         String message = isPrivate ? "메인타임라인이 비공개 처리 되었습니다." : "메인타임라인이 공개 처리 되었습니다.";
         return ResponseEntity.ok(PrivacyUpdateResponseDTO.success(message));
     }
+
+    @PutMapping("/{mainTimelineId}/status")
+    public ResponseEntity<UpdateStatusResponseDTO> updateMainTimelineStatus(@PathVariable Long mainTimelineId, @RequestParam boolean isDone) {
+        try {
+            mainTimelineService.updateMainTimelineStatus(mainTimelineId, isDone);
+            String message = isDone ? "메인타임라인이 완료 상태로 업데이트 되었습니다." : "메인타임라인이 진행중 상태로 업데이트 되었습니다.";
+            return ResponseEntity.ok(UpdateStatusResponseDTO.success(message));
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "메인 타임라인을 찾을 수 없습니다.", e);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(UpdateStatusResponseDTO.failure("상태 업데이트에 실패했습니다."));
+        }
+    }
+
 }

--- a/src/main/java/com/api/RecordTimeline/domain/mainTimeline/domain/MainTimeline.java
+++ b/src/main/java/com/api/RecordTimeline/domain/mainTimeline/domain/MainTimeline.java
@@ -34,6 +34,9 @@ public class MainTimeline extends BaseEntity {
     @Column(nullable = false)
     private boolean isPrivate; // 공개 여부를 저장하는 필드 추가
 
+    @Column(nullable = false)
+    private boolean isDone; // 진행 상태를 저장하는 필드 추가
+
     @Setter
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
@@ -43,12 +46,13 @@ public class MainTimeline extends BaseEntity {
     private List<SubTimeline> subTimelines = new ArrayList<>();
 
     @Builder
-    public MainTimeline(Long id, String title, LocalDate startDate, LocalDate endDate, Member member) {
+    public MainTimeline(Long id, String title, LocalDate startDate, LocalDate endDate, Member member, boolean isPrivate, boolean isDone) {
         this.id = id;
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
-//        this.member = member;
+        this.isPrivate = isPrivate;
+        this.isDone = isDone;
         setMember(member);
     }
 

--- a/src/main/java/com/api/RecordTimeline/domain/mainTimeline/dto/response/ReadResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/mainTimeline/dto/response/ReadResponseDTO.java
@@ -20,11 +20,12 @@ public class ReadResponseDTO {
         private String title;
         private LocalDate startDate;
         private LocalDate endDate;
+        private boolean isDone; // 진행 상태 필드 추가
     }
 
     public static ReadResponseDTO from(List<MainTimeline> timelines) {
         List<TimelineDetails> details = timelines.stream()
-                .map(timeline -> new TimelineDetails(timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate()))
+                .map(timeline -> new TimelineDetails(timeline.getId(), timeline.getTitle(), timeline.getStartDate(), timeline.getEndDate(), timeline.isDone()))
                 .collect(Collectors.toList());
         return new ReadResponseDTO(details);
     }

--- a/src/main/java/com/api/RecordTimeline/domain/mainTimeline/dto/response/UpdateStatusResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/mainTimeline/dto/response/UpdateStatusResponseDTO.java
@@ -1,0 +1,19 @@
+package com.api.RecordTimeline.domain.mainTimeline.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateStatusResponseDTO {
+    private String code;
+    private String message;
+
+    public static UpdateStatusResponseDTO success(String message) {
+        return new UpdateStatusResponseDTO("SU", message);
+    }
+
+    public static UpdateStatusResponseDTO failure(String message) {
+        return new UpdateStatusResponseDTO("UF", message);
+    }
+}

--- a/src/main/java/com/api/RecordTimeline/domain/mainTimeline/service/MainTimelineService.java
+++ b/src/main/java/com/api/RecordTimeline/domain/mainTimeline/service/MainTimelineService.java
@@ -49,6 +49,18 @@ public class MainTimelineService {
                 new NoSuchElementException("해당 ID로 메인 타임라인을 찾을 수 없습니다: " + id));
     }
 
+    // 메인 타임라인 진행 상태 토글
+    public void updateMainTimelineStatus(Long id, boolean isDone) {
+        MainTimeline mainTimeline = mainTimelineRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("해당 ID로 메인 타임라인을 찾을 수 없습니다: " + id));
+
+        checkOwnership(mainTimeline.getMember().getEmail());
+
+        mainTimeline.setDone(isDone);
+        mainTimelineRepository.save(mainTimeline);
+    }
+
+
     // 모든 메인 타임라인 조회
     public List<MainTimeline> getAllMainTimelines() {
         return mainTimelineRepository.findAll();


### PR DESCRIPTION
# 📝 메인타임라인 진행중/완료 상태 확인 API 및 isDone 필드 추가


<br>


- [x] 메인타임라인의 'isDone' 상태를 업데이트할 수 있는 API 생성
1. isDone = true -> 완료 isDone = false -> 진행중
- [x] 'my 메인타임라인 조회' 및 '전체 메인타임라인 조회' API 응답에 'isDone' 필드 추가
- [x] 'UpdateStatusResponseDTO' 클래스 추가하여 상태 업데이트에 대한 응답 표준화시킴
- [x] 추가 기능이나 변경할 기능 있는지 검토 요청