### PR TITLE
RTL 118 be 서브 타임라인 공개여부 설정

### DIFF
--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/controller/SubTimelineController.java
@@ -94,5 +94,12 @@ public class SubTimelineController {
         String mainTimelineTitle = subTimelineService.getMainTimelineTitle(mainTimelineId);
         return ResponseEntity.ok(SubReadResponseDTO.from(subTimelines, mainTimelineTitle));
     }
+
+    // 서브타임라인 진행중 여부 업데이트(완료 또는 진행중)
+    @PutMapping("/{subTimelineId}/done-status")
+    public ResponseEntity<SubUpdateStatusResponseDTO> updateSubTimelineStatus(@PathVariable Long subTimelineId, @RequestParam boolean isDone) {
+        SubUpdateStatusResponseDTO response = subTimelineService.updateSubTimelineStatus(subTimelineId, isDone);
+        return ResponseEntity.ok(response);
+    }
 }
 

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/domain/SubTimeline.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/domain/SubTimeline.java
@@ -45,6 +45,9 @@ public class SubTimeline extends BaseEntity {
     @Column(name = "is_private", nullable = false)
     private boolean isPrivate; // 공개/비공개 여부
 
+    @Column(name = "is_done", nullable = false)
+    private boolean isDone = false; // 진행중 상태 필드
+
     // 북마크 수가 음수가 되지 않도록 검증 메서드 추가
     public void adjustBookmarkCount(int adjustment) {
         this.bookmarkCount += adjustment;

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubMyTimelineResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubMyTimelineResponseDTO.java
@@ -18,6 +18,7 @@ public class SubMyTimelineResponseDTO {
     private int likeCount;
     private int bookmarkCount;
     private boolean isPrivate;
+    private boolean isDone;
 
     // 서브타임라인에서 DTO 생성하는 메서드
     public static SubMyTimelineResponseDTO from(SubTimeline subTimeline) {
@@ -29,7 +30,8 @@ public class SubMyTimelineResponseDTO {
                 subTimeline.getEndDate(),
                 subTimeline.getLikeCount(),
                 subTimeline.getBookmarkCount(),
-                subTimeline.isPrivate()
+                subTimeline.isPrivate(),
+                subTimeline.isDone()
         );
     }
 }

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubReadResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubReadResponseDTO.java
@@ -25,6 +25,7 @@ public class SubReadResponseDTO {
         private int likeCount;
         private int bookmarkCount;
         private boolean isPrivate;
+        private boolean isDone;
     }
 
     public static SubReadResponseDTO from(List<SubTimeline> subTimelines, String mainTimelineTitle) {
@@ -37,7 +38,8 @@ public class SubReadResponseDTO {
                         subTimeline.getEndDate(),
                         subTimeline.getLikeCount(),
                         subTimeline.getBookmarkCount(),
-                        subTimeline.isPrivate()
+                        subTimeline.isPrivate(),
+                        subTimeline.isDone()
                 )).collect(Collectors.toList());
         return new SubReadResponseDTO(details, mainTimelineTitle);
     }
@@ -60,7 +62,8 @@ public class SubReadResponseDTO {
                         subTimeline.getEndDate(),
                         subTimeline.getLikeCount(),
                         subTimeline.getBookmarkCount(),
-                        subTimeline.isPrivate()
+                        subTimeline.isPrivate(),
+                        subTimeline.isDone()
                 )).collect(Collectors.toList());
         return new SubReadResponseDTO(details, mainTimelineTitle);
     }

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubUpdateStatusResponseDTO.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/dto/response/SubUpdateStatusResponseDTO.java
@@ -1,0 +1,21 @@
+package com.api.RecordTimeline.domain.subTimeline.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubUpdateStatusResponseDTO {
+
+    private String code;
+    private String message;
+
+    public static SubUpdateStatusResponseDTO success(boolean isDone) {
+        String message = isDone ? "서브타임라인이 완료 상태로 업데이트 되었습니다." : "서브타임라인이 진행중 상태로 업데이트 되었습니다.";
+        return new SubUpdateStatusResponseDTO("SU", message);
+    }
+
+    public static SubUpdateStatusResponseDTO failure(String message) {
+        return new SubUpdateStatusResponseDTO("UF", message);
+    }
+}

--- a/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
+++ b/src/main/java/com/api/RecordTimeline/domain/subTimeline/service/SubTimelineService.java
@@ -12,6 +12,7 @@ import com.api.RecordTimeline.domain.subTimeline.dto.request.SubTimelineCreateRe
 import com.api.RecordTimeline.domain.subTimeline.dto.response.SubMyTimelineResponseDTO;
 import com.api.RecordTimeline.domain.subTimeline.dto.response.SubPrivacyUpdateResponseDTO;
 import com.api.RecordTimeline.domain.subTimeline.dto.response.SubTimelineWithLikeBookmarkDTO;
+import com.api.RecordTimeline.domain.subTimeline.dto.response.SubUpdateStatusResponseDTO;
 import com.api.RecordTimeline.domain.subTimeline.repository.SubTimelineRepository;
 import com.api.RecordTimeline.global.exception.ApiException;
 import com.api.RecordTimeline.global.exception.ErrorType;
@@ -251,6 +252,31 @@ public class SubTimelineService {
                 .filter(subTimeline -> !subTimeline.isPrivate())
                 .sorted(Comparator.comparing(SubTimeline::getStartDate))  // 시작 날짜 순서대로 정렬
                 .collect(Collectors.toList());
+    }
+
+    public SubPrivacyUpdateResponseDTO setSubTimelineDoneStatus(Long subTimelineId, boolean isDone) {
+        SubTimeline subTimeline = subTimelineRepository.findById(subTimelineId)
+                .orElseThrow(() -> new ApiException(ErrorType._SUBTIMELINE_NOT_FOUND));
+
+        checkOwnership(subTimeline.getMainTimeline().getMember().getEmail());
+
+        subTimeline.setDone(isDone);
+        subTimelineRepository.save(subTimeline);
+
+        String message = isDone ? "서브타임라인이 완료 상태로 업데이트 되었습니다." : "서브타임라인이 진행중 상태로 업데이트 되었습니다.";
+        return SubPrivacyUpdateResponseDTO.success(message);
+    }
+
+    public SubUpdateStatusResponseDTO updateSubTimelineStatus(Long subTimelineId, boolean isDone) {
+        SubTimeline subTimeline = subTimelineRepository.findById(subTimelineId)
+                .orElseThrow(() -> new ApiException(ErrorType._SUBTIMELINE_NOT_FOUND));
+
+        checkOwnership(subTimeline.getMainTimeline().getMember().getEmail());
+
+        subTimeline.setDone(isDone);
+        subTimelineRepository.save(subTimeline);
+
+        return SubUpdateStatusResponseDTO.success(isDone);
     }
 
     private void checkOwnership(String ownerEmail) {


### PR DESCRIPTION
# 📝 서브타임라인 진행중/완료 상태 확인 API 및 isDone 필드 추가


<br>


- [x] 서브타임라인의 'isDone' 상태를 업데이트할 수 있는 API 생성
1. isDone = true -> 완료 isDone = false -> 진행중
- [x] 'my 서브타임라인 조회' 및 '비공개 제외 전체 서브타임라인 조회' API 응답에 'isDone' 필드 추가
- [x] 'SubUpdateStatusResponseDTO' 클래스 추가하여 상태 업데이트에 대한 응답 표준화시킴
- [x] 추가 기능이나 변경할 기능 있는지 검토 요청